### PR TITLE
Add Next.js client and FastAPI server skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+__pycache__/
+*.py[cod]
+.env
+server/data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # openai-codex-test
+
+This repository contains a sample Next.js + TypeScript client and a FastAPI server that demonstrates how to interact with the Korea Investment & Securities (KIS) API. The server exposes endpoints to query stocks based on short-term, medium-term and long-term strategies (qualitative or quantitative) and periodically fetches chart data for analysis. The client provides a minimal UI that fetches data from the server.
+
+## Structure
+
+- `client/` – Next.js application (app directory).
+- `server/` – FastAPI application.
+- `.gitignore` – ignores runtime files, node modules, and environment files.
+
+## Usage
+
+1. Copy `.env.example` to `.env` in both `client` and `server` directories and fill in the required values.
+2. Install dependencies:
+
+```bash
+cd server && pip install -r requirements.txt
+cd ../client && npm install
+```
+
+3. Run the API server:
+
+```bash
+cd server
+uvicorn main:app --reload
+```
+
+4. Start the Next.js development server:
+
+```bash
+cd client
+npm run dev
+```
+
+The client will fetch stock data from the FastAPI server.

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+interface Stock {
+  symbol: string;
+  name: string;
+}
+
+export default function HomePage() {
+  const [stocks, setStocks] = useState<Stock[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    async function fetchStocks() {
+      setLoading(true);
+      const url = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+      const res = await fetch(`${url}/stocks?term=short&strategy=qualitative`);
+      const data = await res.json();
+      setStocks(data.data);
+      setLoading(false);
+    }
+    fetchStocks();
+  }, []);
+
+  return (
+    <main>
+      <h1>Stock Strategies</h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <ul>
+          {stocks.map((s) => (
+            <li key={s.symbol}>{s.symbol} - {s.name}</li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/client/next-env.d.ts
+++ b/client/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "client",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.10.5",
+    "@types/react": "18.2.14",
+    "eslint": "8.53.0",
+    "eslint-config-next": "13.5.6",
+    "typescript": "5.2.2"
+  }
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,1 @@
+KIS_API_KEY=your_api_key_here

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,62 @@
+import os
+import json
+from datetime import date
+from typing import List
+
+import httpx
+from fastapi import FastAPI, BackgroundTasks
+from pydantic import BaseModel, BaseSettings
+
+
+class Settings(BaseSettings):
+    kis_api_key: str = ""
+
+    class Config:
+        env_file = ".env"
+
+
+def get_settings() -> Settings:
+    return Settings()
+
+
+settings = get_settings()
+app = FastAPI(title="KIS Stock API")
+
+
+class Stock(BaseModel):
+    symbol: str
+    name: str
+
+
+async def fetch_stocks(term: str, strategy: str) -> List[Stock]:
+    # TODO: Replace with real API call using settings.kis_api_key
+    await httpx.AsyncClient().get("https://example.com")
+    return [
+        Stock(symbol="000000", name="Placeholder Corp"),
+    ]
+
+
+@app.get("/stocks")
+async def get_stocks(term: str, strategy: str):
+    stocks = await fetch_stocks(term, strategy)
+    return {"term": term, "strategy": strategy, "data": [s.dict() for s in stocks]}
+
+
+async def fetch_chart_data() -> None:
+    # TODO: call KIS API to fetch chart data
+    os.makedirs("data", exist_ok=True)
+    path = os.path.join("data", f"chart_{date.today()}.json")
+    with open(path, "w") as f:
+        json.dump({"message": "placeholder chart data"}, f)
+
+
+@app.post("/fetch-charts")
+async def schedule_fetch_charts(background_tasks: BackgroundTasks):
+    background_tasks.add_task(fetch_chart_data)
+    return {"status": "scheduled"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+python-dotenv
+httpx


### PR DESCRIPTION
## Summary
- add project README with usage instructions
- add gitignore for Node and Python artifacts
- create Next.js app directory with TypeScript
- create FastAPI server with placeholder KIS API integration
- provide example `.env` files

## Testing
- `python3 -m py_compile server/main.py`
- `node -e "const pkg=require('./client/package.json'); console.log(pkg.name)"`


------
https://chatgpt.com/codex/tasks/task_e_68831a97cb4083329f02125a82c006ca