### PR TITLE
다중 전략 지원 및 서버 구조 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,34 @@
 # openai-codex-test
 
-This repository contains a sample Next.js + TypeScript client and a FastAPI server that demonstrates how to interact with the Korea Investment & Securities (KIS) API. The server exposes endpoints to query stocks based on short-term, medium-term and long-term strategies (qualitative or quantitative) and periodically fetches chart data for analysis. The client provides a minimal UI that fetches data from the server.
+이 저장소는 Next.js + TypeScript로 작성된 클라이언트와 FastAPI 기반 서버 예제를 포함합니다. 서버는 다양한 주식 및 차트 전략을 조회할 수 있는 API를 제공하며, 클라이언트는 간단한 UI로 해당 데이터를 표시합니다.
 
-## Structure
+## 구조
 
-- `client/` – Next.js application (app directory).
-- `server/` – FastAPI application.
-- `.gitignore` – ignores runtime files, node modules, and environment files.
+- `client/` – Next.js 애플리케이션
+- `server/` – FastAPI 애플리케이션
 
-## Usage
+## 사용 방법
 
-1. Copy `.env.example` to `.env` in both `client` and `server` directories and fill in the required values.
-2. Install dependencies:
+1. 서버와 클라이언트 디렉터리 각각에 `.env` 파일을 생성하여 필요한 값을 입력합니다.
+2. 의존성 설치:
 
 ```bash
 cd server && pip install -r requirements.txt
 cd ../client && npm install
 ```
 
-3. Run the API server:
+3. API 서버 실행:
 
 ```bash
 cd server
 uvicorn main:app --reload
 ```
 
-4. Start the Next.js development server:
+4. Next.js 개발 서버 실행:
 
 ```bash
 cd client
 npm run dev
 ```
 
-The client will fetch stock data from the FastAPI server.
+실행 후 브라우저에서 주식 전략과 차트 데이터를 확인할 수 있습니다.

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -1,0 +1,34 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f6f8;
+  color: #222;
+}
+
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.title {
+  color: #3182f6;
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.select {
+  padding: 0.5rem;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+  margin-bottom: 1rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+}
+
+.list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #eee;
+}

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="ko">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -6,31 +6,47 @@ interface Stock {
   name: string;
 }
 
+const strategies = ['qualitative', 'quantitative', 'momentum'];
+
 export default function HomePage() {
   const [stocks, setStocks] = useState<Stock[]>([]);
   const [loading, setLoading] = useState(false);
+  const [strategy, setStrategy] = useState(strategies[0]);
 
   useEffect(() => {
     async function fetchStocks() {
       setLoading(true);
       const url = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-      const res = await fetch(`${url}/stocks?term=short&strategy=qualitative`);
+      const res = await fetch(`${url}/stocks?term=short&strategy=${strategy}`);
       const data = await res.json();
       setStocks(data.data);
       setLoading(false);
     }
     fetchStocks();
-  }, []);
+  }, [strategy]);
 
   return (
-    <main>
-      <h1>Stock Strategies</h1>
+    <main className="container">
+      <h1 className="title">주식 전략 보기</h1>
+      <select
+        value={strategy}
+        onChange={(e) => setStrategy(e.target.value)}
+        className="select"
+      >
+        {strategies.map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
       {loading ? (
-        <p>Loading...</p>
+        <p>로딩중...</p>
       ) : (
-        <ul>
+        <ul className="list">
           {stocks.map((s) => (
-            <li key={s.symbol}>{s.symbol} - {s.name}</li>
+            <li key={s.symbol}>
+              {s.symbol} - {s.name}
+            </li>
           ))}
         </ul>
       )}

--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+from .config import get_settings
+from .routers import stocks, charts
+
+# 환경 설정을 불러옵니다
+settings = get_settings()
+
+# FastAPI 애플리케이션 생성
+app = FastAPI(title="KIS Stock API")
+app.include_router(stocks.router, prefix="/stocks", tags=["stocks"])
+app.include_router(charts.router, prefix="/charts", tags=["charts"])
+

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -1,0 +1,12 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    # KIS API 키를 환경 변수에서 불러옵니다
+    kis_api_key: str = ""
+
+    class Config:
+        env_file = ".env"
+
+
+def get_settings() -> Settings:
+    return Settings()

--- a/server/app/routers/__init__.py
+++ b/server/app/routers/__init__.py
@@ -1,0 +1,3 @@
+from . import stocks, charts
+
+__all__ = ["stocks", "charts"]

--- a/server/app/routers/charts.py
+++ b/server/app/routers/charts.py
@@ -1,0 +1,32 @@
+import os
+import json
+from datetime import date
+from fastapi import APIRouter, BackgroundTasks, HTTPException
+
+# 차트 관련 라우터
+router = APIRouter()
+
+def chart_path(strategy: str) -> str:
+    """전략별 차트 데이터 파일 경로를 생성합니다."""
+    os.makedirs("data", exist_ok=True)
+    return os.path.join("data", f"chart_{strategy}_{date.today()}.json")
+
+async def fetch_chart_data(strategy: str) -> None:
+    """차트 데이터를 가져와 저장합니다 (예제)."""
+    # TODO: KIS API 호출로 대체하세요
+    path = chart_path(strategy)
+    with open(path, "w") as f:
+        json.dump({"message": f"placeholder chart data for {strategy}"}, f)
+
+@router.post("/fetch")
+async def schedule_fetch_charts(strategy: str, background_tasks: BackgroundTasks):
+    background_tasks.add_task(fetch_chart_data, strategy)
+    return {"status": "scheduled", "strategy": strategy}
+
+@router.get("")
+async def get_chart(strategy: str):
+    path = chart_path(strategy)
+    if not os.path.exists(path):
+        raise HTTPException(status_code=404, detail="데이터가 없습니다")
+    with open(path) as f:
+        return json.load(f)

--- a/server/app/routers/stocks.py
+++ b/server/app/routers/stocks.py
@@ -1,0 +1,24 @@
+from typing import List
+from fastapi import APIRouter
+from pydantic import BaseModel
+import httpx
+
+# 주식 관련 라우터
+router = APIRouter()
+
+class Stock(BaseModel):
+    """주식 기본 정보"""
+
+    symbol: str
+    name: str
+
+async def fetch_stocks(term: str, strategy: str) -> List[Stock]:
+    """KIS API에서 주식 목록을 가져옵니다 (예제)."""
+    # TODO: 실제 KIS API 호출로 교체하세요
+    await httpx.AsyncClient().get("https://example.com")
+    return [Stock(symbol="000000", name="Placeholder Corp")]
+
+@router.get("")
+async def get_stocks(term: str, strategy: str):
+    stocks = await fetch_stocks(term, strategy)
+    return {"term": term, "strategy": strategy, "data": [s.dict() for s in stocks]}

--- a/server/main.py
+++ b/server/main.py
@@ -1,62 +1,7 @@
-import os
-import json
-from datetime import date
-from typing import List
-
-import httpx
-from fastapi import FastAPI, BackgroundTasks
-from pydantic import BaseModel, BaseSettings
-
-
-class Settings(BaseSettings):
-    kis_api_key: str = ""
-
-    class Config:
-        env_file = ".env"
-
-
-def get_settings() -> Settings:
-    return Settings()
-
-
-settings = get_settings()
-app = FastAPI(title="KIS Stock API")
-
-
-class Stock(BaseModel):
-    symbol: str
-    name: str
-
-
-async def fetch_stocks(term: str, strategy: str) -> List[Stock]:
-    # TODO: Replace with real API call using settings.kis_api_key
-    await httpx.AsyncClient().get("https://example.com")
-    return [
-        Stock(symbol="000000", name="Placeholder Corp"),
-    ]
-
-
-@app.get("/stocks")
-async def get_stocks(term: str, strategy: str):
-    stocks = await fetch_stocks(term, strategy)
-    return {"term": term, "strategy": strategy, "data": [s.dict() for s in stocks]}
-
-
-async def fetch_chart_data() -> None:
-    # TODO: call KIS API to fetch chart data
-    os.makedirs("data", exist_ok=True)
-    path = os.path.join("data", f"chart_{date.today()}.json")
-    with open(path, "w") as f:
-        json.dump({"message": "placeholder chart data"}, f)
-
-
-@app.post("/fetch-charts")
-async def schedule_fetch_charts(background_tasks: BackgroundTasks):
-    background_tasks.add_task(fetch_chart_data)
-    return {"status": "scheduled"}
-
+# 라우팅이 포함된 FastAPI 애플리케이션
+from app import app
 
 if __name__ == "__main__":
     import uvicorn
-
     uvicorn.run(app, host="0.0.0.0", port=8000)
+


### PR DESCRIPTION
## Summary
- 서버를 라우터 구조로 분리해 유지보수성 향상
- 차트 전략별 데이터 처리 기능 추가
- 클라이언트 UI를 간단한 토스 스타일로 개선
- README와 주석을 한글로 수정

## Testing
- `python -m py_compile server/main.py server/app/*.py server/app/routers/*.py`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68832d50cbf083328331f7ddf04be73a