### PR TITLE
Improve frontend style and add simple chart

### DIFF
--- a/client/app/global.css
+++ b/client/app/global.css
@@ -1,0 +1,40 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+  background: #f4f4f7;
+  color: #333;
+}
+
+h1 {
+  color: #0d6efd;
+}
+
+.chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  margin-top: 2rem;
+  height: 200px;
+}
+
+.chart-bar {
+  background: #0d6efd;
+  width: 40px;
+  border-radius: 4px 4px 0 0;
+  transition: background 0.3s;
+}
+
+.chart-bar:hover {
+  background: #084298;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -1,0 +1,17 @@
+import './global.css';
+
+export const metadata = {
+  title: 'Stock Strategies',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -6,17 +6,28 @@ interface Stock {
   name: string;
 }
 
+interface ChartData {
+  labels: string[];
+  values: number[];
+}
+
 export default function HomePage() {
   const [stocks, setStocks] = useState<Stock[]>([]);
+  const [chart, setChart] = useState<ChartData>({ labels: [], values: [] });
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     async function fetchStocks() {
       setLoading(true);
       const url = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-      const res = await fetch(`${url}/stocks?term=short&strategy=qualitative`);
-      const data = await res.json();
-      setStocks(data.data);
+      const [stockRes, chartRes] = await Promise.all([
+        fetch(`${url}/stocks?term=short&strategy=qualitative`),
+        fetch(`${url}/chart`),
+      ]);
+      const stockData = await stockRes.json();
+      const chartData = await chartRes.json();
+      setStocks(stockData.data);
+      setChart(chartData);
       setLoading(false);
     }
     fetchStocks();
@@ -28,11 +39,26 @@ export default function HomePage() {
       {loading ? (
         <p>Loading...</p>
       ) : (
-        <ul>
-          {stocks.map((s) => (
-            <li key={s.symbol}>{s.symbol} - {s.name}</li>
-          ))}
-        </ul>
+        <>
+          <ul>
+            {stocks.map((s) => (
+              <li key={s.symbol}>{s.symbol} - {s.name}</li>
+            ))}
+          </ul>
+          <div className="chart">
+            {chart.labels.map((label, i) => (
+              <div
+                key={label}
+                className="chart-bar"
+                style={{ height: `${chart.values[i]}px` }}
+              >
+                <span className="sr-only">
+                  {label}: {chart.values[i]}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
       )}
     </main>
   );

--- a/server/main.py
+++ b/server/main.py
@@ -43,17 +43,34 @@ async def get_stocks(term: str, strategy: str):
 
 
 async def fetch_chart_data() -> None:
-    # TODO: call KIS API to fetch chart data
+    """Generate placeholder chart data and save it to disk."""
     os.makedirs("data", exist_ok=True)
     path = os.path.join("data", f"chart_{date.today()}.json")
+    # Simple dataset of random stock prices
+    data = {
+        "labels": ["AAA", "BBB", "CCC", "DDD"],
+        "values": [100, 80, 120, 60],
+    }
     with open(path, "w") as f:
-        json.dump({"message": "placeholder chart data"}, f)
+        json.dump(data, f)
 
 
 @app.post("/fetch-charts")
 async def schedule_fetch_charts(background_tasks: BackgroundTasks):
     background_tasks.add_task(fetch_chart_data)
     return {"status": "scheduled"}
+
+
+@app.get("/chart")
+async def get_chart():
+    """Return the latest chart data."""
+    path = os.path.join("data", f"chart_{date.today()}.json")
+    if not os.path.exists(path):
+        await fetch_chart_data()
+    if os.path.exists(path):
+        with open(path) as f:
+            return json.load(f)
+    return {"labels": [], "values": []}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- create global layout and styles for the Next.js app
- implement a lightweight bar chart in the client
- generate placeholder chart data in FastAPI server and expose `/chart` endpoint

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883593872448332863862330df730ba